### PR TITLE
Add VS-Code style package.json, importable also by IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-target
-bin
-.settings
+# Maven
+target/
+
+# Eclipse
+bin/
+.settings/
+
+# IntelliJ IDEA
+.idea/

--- a/io.github.datho7561.jikespg/syntaxes/package.json
+++ b/io.github.datho7561.jikespg/syntaxes/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "jikespg",
+  "version": "0.2.0-SNAPSHOT",
+  "description": "jikespg",
+  "license": "EPL-2.0",
+  "contributes": {
+    "languages": [
+      {
+        "id": "jikespg",
+        "extensions": [
+          ".g"
+        ]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "jikespg",
+        "scopeName": "source.jikespg",
+        "path": "./jikespg.json"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
@datho7561: Thanks for your pointers to IntelliJ documentation on the mailing list. I googled a bit about the open question how to create a bundle importable by IDEA. As it turnes out, the only thing missing is a _package.json_ file in Visual Studio Code style.

References:
  - https://youtrack.jetbrains.com/issue/IDEA-300626
  - https://code.visualstudio.com/api/references/extension-manifest
  - https://spdx.org/licenses/EPL-2.0.html

FYI, this is what the beginning of the AspectJ grammar (derived from Eclipse JDT Java grammar) looks like in IDEA now:

![image](https://github.com/datho7561/eclipse-jikespg/assets/1537384/194ac965-3c4e-420b-903b-b04d3b59ee3a)

